### PR TITLE
fix(docs): fix `DataTableColumnHeader` usage

### DIFF
--- a/apps/www/src/content/docs/components/data-table.md
+++ b/apps/www/src/content/docs/components/data-table.md
@@ -971,11 +971,9 @@ export const columns = [
   {
     accessorKey: "email",
     header: ({ column }) => (
-        return h(DataTableColumnHeader, {
-            props: {
-                column: column,
-                title: 'Email'
-            }
+        h(DataTableColumnHeader, {
+            column: column,
+            title: 'Email'
         })
     ),
   },


### PR DESCRIPTION
Just a minor hick-up I stumbled upon while following the guide in the docs